### PR TITLE
Not quoting a scalar starting with the "%" character is deprecated

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -123,7 +123,7 @@ You may want to add some configuration to your `config.yml`
 # app/config/config.yml
 resque:
     class: Mpclarkson\ResqueBundle\Resque    # the resque class if different from default
-    vendor_dir: %kernel.root_dir%/../vendor  # the vendor dir if different from default
+    vendor_dir: "%kernel.root_dir%/../vendor"  # the vendor dir if different from default
     app_include: /pathto/bootstrap.php.cache # app include file if different from default
     prefix: my-resque-prefix                 # optional prefix to separate Resque data per site/app
     redis:


### PR DESCRIPTION
Not quoting a scalar starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0

(also see comments in http://symfony.com/blog/new-in-symfony-2-8-yaml-deprecations)
