### PR TITLE
Fix StopWorkerCommand

### DIFF
--- a/Command/StopWorkerCommand.php
+++ b/Command/StopWorkerCommand.php
@@ -22,7 +22,7 @@ class StopWorkerCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $resque = $this->getContainer()->get('resque.resque');
+        $resque = $this->getContainer()->get('resque');
 
         if ($input->getOption('all')) {
             $workers = $resque->getWorkers();


### PR DESCRIPTION
The name of the service is "resque" in the container, not "resque.resque" - this PR fixes an error when trying to stop workers with command

> app/console resque:worker-stop

The error before this PR is 

```
 [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]  
  You have requested a non-existent service "resque.resque".
```
