### PR TITLE
SIGKILL has different int values on different platforms

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -23,7 +23,7 @@ class Worker
     {
         $parts = \explode(':', $this->getId());
 
-        \posix_kill($parts[1], 3);
+        \posix_kill($parts[1], SIGKILL);
     }
 
     public function getQueues()


### PR DESCRIPTION
on my mac it was impossible to stop workers so I dug deep to work out why. 

You had hard coded SIGKILL as "3"

This doesnt work on a mac - (my development platform!) see: https://developer.apple.com/library/ios/documentation/System/Conceptual/ManPages_iPhoneOS/man3/signal.3.html where is states SIGKILL is 9 and further confirmed that these constants are different on other platforms at http://php.net/manual/en/function.posix-kill.php#102846

Using the `SIGKILL` constant instead will overcome this issue
