### PR TITLE
Fix for worker not being unregistered after being stopped

### DIFF
--- a/Command/StopWorkerCommand.php
+++ b/Command/StopWorkerCommand.php
@@ -50,6 +50,7 @@ class StopWorkerCommand extends ContainerAwareCommand
         foreach ($workers as $worker) {
             $output->writeln(\sprintf('Stopping %s...', $worker->getId()));
             $worker->stop();
+            $worker->getWorker()->unregisterWorker();
         }
 
         return 0;


### PR DESCRIPTION
After stopping workers they are not being cleaned from redis and so you can repeatedly run the stop command and get something like:

```
Phils-Main-iMac:fireup phil$ php app/console resque:worker-start "*"
Starting worker nohup /usr/local/Cellar/php70/7.0.9/bin/php  /Users/phil/Sites/fireup/vendor/mpclarkson/resque-bundle/Command/../bin/resque > /Users/phil/Sites/fireup/var/logs/resque.log 2>&1 & echo $!
Worker started Phils-Main-iMac.local:29480:*
Phils-Main-iMac:fireup phil$ php app/console resque:worker-stop -a
Stopping Phils-Main-iMac.local:29480:*...
Phils-Main-iMac:fireup phil$ php app/console resque:worker-stop -a
Stopping Phils-Main-iMac.local:29480:*...
Phils-Main-iMac:fireup phil$ php app/console resque:worker-stop -a
Stopping Phils-Main-iMac.local:29480:*...
Phils-Main-iMac:fireup phil$ php app/console resque:worker-stop -a
Stopping Phils-Main-iMac.local:29480:*...
Phils-Main-iMac:fireup phil$ php app/console resque:worker-stop -a
Stopping Phils-Main-iMac.local:29480:*...
Phils-Main-iMac:fireup phil$ php app/console resque:worker-stop -a
Stopping Phils-Main-iMac.local:29480:*...

```

Even though the process was stopped on the first command call. 

This PR will unregister the worker after the pid is SIGKILL'ed which is what needs to happen.
