### PR TITLE
Display warning If there are no running workers and you try to stop them

### DIFF
--- a/Command/StopWorkerCommand.php
+++ b/Command/StopWorkerCommand.php
@@ -38,7 +38,7 @@ class StopWorkerCommand extends ContainerAwareCommand
                         $output->writeln($worker->getId());
                     }
                 } else {
-                    $output->writeln('<error>There are no running workers to stop.</error>');
+                    $output->writeln('<error>There are no running workers.</error>');
                 }
 
                 return 1;

--- a/Command/StopWorkerCommand.php
+++ b/Command/StopWorkerCommand.php
@@ -38,7 +38,7 @@ class StopWorkerCommand extends ContainerAwareCommand
                         $output->writeln($worker->getId());
                     }
                 } else {
-                    $output->writeln('<error>There is no running worker.</error>');
+                    $output->writeln('<error>There are no running workers to stop.</error>');
                 }
 
                 return 1;
@@ -47,6 +47,12 @@ class StopWorkerCommand extends ContainerAwareCommand
             $workers = array($worker);
         }
 
+        if (!count($workers)) {
+            $output->writeln('<error>There are no running workers to stop.</error>');
+
+            return 0;
+        }
+        
         foreach ($workers as $worker) {
             $output->writeln(\sprintf('Stopping %s...', $worker->getId()));
             $worker->stop();


### PR DESCRIPTION
Before this PR there would be no output if you attempted to stop all workers, when there were no active workers. 

After this PR you get told there are no running workers to stop

Also fixes some english :-)
