### PR TITLE
Remove strict commit requirements for php-resque

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "symfony/framework-bundle": ">=2.8,<4.0",
         "symfony/console": ">=2.8,<4.0",
         "symfony/process": ">=2.8,<4.0",
-        "chrisboulton/php-resque": "dev-master#df69e8980cc21652f10cd775cb6a0e8c572ffd2d",
-        "chrisboulton/php-resque-scheduler": "dev-master#ab8bd52949cac1f815bbb97aa39f51c7b5766a86"
+        "chrisboulton/php-resque": "dev-master",
+        "chrisboulton/php-resque-scheduler": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "~4"


### PR DESCRIPTION
I want to use a forked version of `php-resque` because I'm waiting for [PR to get merged](https://github.com/chrisboulton/php-resque/pull/296) but with the current strict dependencies it's impossible.

```
- mpclarkson/resque-bundle 1.x-dev requires chrisboulton/php-resque dev-master#df69e8980cc21652f10cd775cb6a0e8c572ffd2d -> satisfiable by chrisboulton/php-resque[dev-master].
```

Can we just remove it and let the developer who requires this bundle decide? 
