### PR TITLE
StartWorkerCommand: Return valid response

### DIFF
--- a/Command/StartWorkerCommand.php
+++ b/Command/StartWorkerCommand.php
@@ -149,6 +149,8 @@ class StartWorkerCommand extends ContainerAwareCommand
             if (!$input->getOption('quiet')) {
                 $output->writeln(\sprintf('<info>Worker started</info> %s:%s:%s', $hostname, $pid, $input->getArgument('queues')));
             }
+
+            return 0;
         }
     }
 }


### PR DESCRIPTION
Return a valid response to the deployment tools like the one that we have on `Command/StopWorkerCommand.php`
